### PR TITLE
Changing frequency of water pwm to 8Hz

### DIFF
--- a/furnace.c
+++ b/furnace.c
@@ -87,7 +87,6 @@ typedef struct {
 #if CONFIG_WATER
   #define WATER_PIN 12
   #define WATER_PIN_SLICE pwm_gpio_to_slice_num(WATER_PIN)
-  #define WATER_OFFSET 40
 #endif
 
 #include "pwm.c"
@@ -160,22 +159,7 @@ tcp_server_recv_(furnace_context_t *ctx, struct tcp_pcb* tpcb, struct pbuf* p)
 #if CONFIG_WATER
 static void
 handle_command_water(furnace_context_t* ctx, void (*feedback)(const char *, const size_t), unsigned arg) {
-    if(arg < 0){
-      const char msg[] = "water pwm argument too small!\r\n";
-      const size_t msg_len = sizeof(msg)-1;
-      feedback(msg, msg_len);
-      return;
-    }
-
-    if(arg > 10){
-      const char msg[] = "water pwm argument too big!\r\n";
-      const size_t msg_len = sizeof(msg)-1;
-      feedback(msg, msg_len);
-      return;
-    }
-
-    const int pwm_value = arg == 0 ? 0 : arg + WATER_OFFSET;
-    const int res = set_pwm_safe(WATER_PIN, ctx, pwm_value);
+    const int res = set_pwm_safe(WATER_PIN, ctx, arg);
 
     if(res == 0)
       return;

--- a/pwm.c
+++ b/pwm.c
@@ -30,7 +30,8 @@ set_pwm_safe(unsigned pin, furnace_context_t *ctx, unsigned new_pwm)
     case WATER_PIN:
       ctx->pwm_water = new_pwm;
 
-      pwm_set_gpio_level(WATER_PIN, new_pwm);
+      const unsigned water_new_pwm_scaled = pwm_scale_level(new_pwm);
+      pwm_set_gpio_level(WATER_PIN, water_new_pwm_scaled);
       break;
 #endif
 
@@ -89,7 +90,7 @@ init_pwm(void)
   pwm_set_irq_enabled(WATER_PIN_SLICE, false);
 
   pwm_config water_cfg = pwm_get_default_config();
-  pwm_config_set_wrap(&water_cfg, MAX_PWM);
+  pwm_config_freq(&water_cfg);
 
   pwm_set_gpio_level(WATER_PIN, 0);
   pwm_init(WATER_PIN_SLICE, &water_cfg, true);


### PR DESCRIPTION
Due to too high frequency water motor took it as an average value of input_voltage * cur_pwm / MAX_PWM. Becouse of the threshold voltage motor couldn't move. Lowering the frequency of pwm allows us to have the full resolution of pwm, without cutting of the lowest values.