### PR TITLE
Update Makefile - adding no hands flahing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ ninja: build/
 
 build/furnace.uf2: ninja
 flash: build/furnace.uf2
-	scripts/rpiflash.sh $(RPI_USB)
+	picotool load -f build/furnace.uf2
 
 clean:
 	rm -rf build/


### PR DESCRIPTION
You need to install picotool from AUR for proper work, it finds picos flash them without bootsel and restart after flashing.

`yay -S picotool`

This lane in CMakeLists.txt is necessary:

`pico_enable_stdio_usb(${PROJECT_NAME} 1)`